### PR TITLE
Account for non-standard post type menu locations

### DIFF
--- a/post-type-archive-descriptions.php
+++ b/post-type-archive-descriptions.php
@@ -45,6 +45,31 @@ function ptad_get_post_types() {
 }
 
 /**
+ * Output filterable parent of Settings page
+ *
+ * @param string $post_type name of post type for the page
+ * @return bool|string parent for settings page
+ */
+function ptad_settings_page_parent( $post_type, $show_in_menu = false ) {
+ 
+	$settings_page_parent = $show_in_menu;
+	
+	// Default is standard post type editing screen
+	if( $settings_page_parent && is_bool( $settings_page_parent ) ) {
+		$settings_page_parent = "edit.php?post_type=$post_type";
+	}
+	
+	/**
+	 * filter for admin menu label
+	 *
+	 * @var string $settings_page_parent label text (default: "edit.php?post_type=$post_type")
+	 * @var string $post_type post_type name if needed
+	 */
+	$settings_page_parent = apply_filters( 'ptad_admin_parent', $settings_page_parent, $post_type );
+	return $settings_page_parent;
+}
+
+/**
  * Output filterable name of Settings page
  * 
  * @param string $post_type name of post type for the page
@@ -108,8 +133,12 @@ function ptad_enable_pages() {
 
 		if( post_type_exists( $post_type ) ) {
 
+				// Check if post type has a particular parent menu location
+				$post_type_object = get_post_type_object( $post_type );
+				$show_in_menu     = $post_type_object->show_in_menu;
+		    
 			add_submenu_page(
-				'edit.php?post_type=' . $post_type, // $parent_slug
+				ptad_settings_page_parent( $post_type, $show_in_menu ), // $parent slug
 				ptad_settings_page_title( $post_type, 'name' ), // $page_title
 				ptad_settings_menu_label( $post_type, 'name' ), // $menu_label
 				ptad_allow_edit_posts(), // $capability

--- a/post-type-archive-descriptions.php
+++ b/post-type-archive-descriptions.php
@@ -136,6 +136,7 @@ function ptad_enable_pages() {
 				// Check if post type has a particular parent menu location
 				$post_type_object = get_post_type_object( $post_type );
 				$show_in_menu     = $post_type_object->show_in_menu;
+				$callback         = ( $show_in_menu && is_bool( $show_in_menu ) ) ? 'standard' : 'custom';
 		    
 			add_submenu_page(
 				ptad_settings_page_parent( $post_type, $show_in_menu ), // $parent slug
@@ -143,7 +144,7 @@ function ptad_enable_pages() {
 				ptad_settings_menu_label( $post_type, 'name' ), // $menu_label
 				ptad_allow_edit_posts(), // $capability
 				$post_type . '-description', // $menu_slug
-				'ptad_settings_page' // $function
+				'ptad_settings_' . $callback // $function
 			);
 
 		} // end if
@@ -270,11 +271,29 @@ function ptad_editor_field( $args ) {
 }
 
 /**
- * Output settings pages
+ * Output settings pages for standard CPT setup
  */
-function ptad_settings_page() {
+function ptad_settings_standard() {
 	$screen = get_current_screen();
 	$post_type = $screen->post_type;
+	
+	ptad_settings_page( $post_type );
+}
+
+/**
+ * Output settings pages for custom CPT setup
+ */
+function ptad_settings_custom() {
+	$page = $_GET['page'];
+	$post_type = str_replace( '-description', '', $page );
+	
+	ptad_settings_page( $post_type );
+}
+
+/**
+ * Output settings pages
+ */
+function ptad_settings_page( $post_type ) {
 	?>
 	<div class="wrap">
 		<h2><?php echo ptad_settings_page_title( $post_type, 'name' ); ?></h2>

--- a/post-type-archive-descriptions.php
+++ b/post-type-archive-descriptions.php
@@ -4,7 +4,7 @@ Plugin Name: Post Type Archive Descriptions
 Description: Enables an editable description for a post type to display at the top of the post type archive page.
 Author: Mark Root-Wiley, MRW Web Design, NonprofitWP.org
 Author URI: https://MRWweb.com
-Version: 1.2.beta
+Version: 1.2.beta2
 License: GPL v3
 Text Domain: post-type-archive-descriptions
 

--- a/post-type-archive-descriptions.php
+++ b/post-type-archive-descriptions.php
@@ -60,9 +60,9 @@ function ptad_settings_page_parent( $post_type, $show_in_menu = false ) {
 	}
 	
 	/**
-	 * filter for admin menu label
+	 * filter for parent of Archive Settings page
 	 *
-	 * @var string $settings_page_parent label text (default: "edit.php?post_type=$post_type")
+	 * @var string $settings_page_parent address (default: "edit.php?post_type=$post_type")
 	 * @var string $post_type post_type name if needed
 	 */
 	$settings_page_parent = apply_filters( 'ptad_admin_parent', $settings_page_parent, $post_type );

--- a/post-type-archive-descriptions.php
+++ b/post-type-archive-descriptions.php
@@ -4,7 +4,7 @@ Plugin Name: Post Type Archive Descriptions
 Description: Enables an editable description for a post type to display at the top of the post type archive page.
 Author: Mark Root-Wiley, MRW Web Design, NonprofitWP.org
 Author URI: https://MRWweb.com
-Version: 1.1.5
+Version: 1.2.beta
 License: GPL v3
 Text Domain: post-type-archive-descriptions
 

--- a/post-type-archive-descriptions.php
+++ b/post-type-archive-descriptions.php
@@ -370,10 +370,12 @@ function ptad_admin_bar_links( $admin_bar ) {
 		 */
 		$link_text = apply_filters( 'ptad_edit_description_link', $link_text, $post_type_name );
 
+		$parent_page = ptad_settings_page_parent( $post_type, $post_type_object->show_in_menu );
+		
 		$args = array(
 			'id'    => 'wp-admin-bar-edit',
 			'title' => $link_text,
-			'href'  => admin_url( 'edit.php?post_type=' . $post_type . '&page=' . $post_type . '-description' )
+			'href'  => admin_url( $parent_page . '&page=' . $post_type . '-description' )
 		);
 		$admin_bar->add_menu( $args );
 	}


### PR DESCRIPTION
Since a post type can be registered with a non-standard location, it seems reasonable to account for this by setting up a function to check for the post type's `show_in_menu` setting. If it's set to a specific location, the modified plugin will use that for the parent location.

At that point, the $_GET['post_type'] parameter may not be reflective of the correct post type, but the $_GET['page'] parameter is generated by the plugin, so we use that as a reference for generating the appropriate metabox.

This addresses issue #9. It has not been extensively tested yet.