### PR TITLE
new wpml/polylang config file to allow translation of post type archives

### DIFF
--- a/wpml-config.xml
+++ b/wpml-config.xml
@@ -1,0 +1,8 @@
+<!-- Add support for WPML and Polylang -->
+<wpml-config>
+	<admin-texts>
+		<key name="ptad_descriptions">
+			<key name="*"/>
+		</key>
+	</admin-texts>
+</wpml-config>


### PR DESCRIPTION
Add support for WPML and Polylang string translations. Closes #6 and #7.