### PR TITLE
Coding standards & The Events Calendar Adjustments

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -4,3 +4,4 @@
 
 .distignore
 .gitignore
+.phpcs.xml

--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Post Type Archive Descriptions" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/squizlabs/PHP_CodeSniffer/master/phpcs.xsd">
+	<description>WordPress Code Sniffs for Post Type Archive Descriptions</description>
+
+    <file>./post-type-archive-descriptions.php</file>
+    <file>./compat/qtranslate-x.php</file>
+    <file>./compat/the-events-calendar.php</file>
+    <file>./compat/wordpress-core.php</file>
+
+    <rule ref="WordPress-Extra">
+		<!--
+		Run `phpcs` with the '-s' flag, which allows us to
+		see the names of the sniffs reporting errors.
+		Once we know the sniff names, we can opt to exclude sniffs which don't
+		suit our project like so.
+        -->
+	</rule>
+
+    <config name="minimum_supported_wp_version" value="4.6"/>
+
+    <rule ref="WordPress.WP.I18n">
+		<properties>
+			<property name="text_domain" type="array">
+				<element value="post-type-archive-descriptions"/>
+			</property>
+		</properties>
+	</rule>
+
+    <rule ref="WordPress.NamingConventions.PrefixAllGlobals">
+		<properties>
+			<property name="prefixes" type="array">
+				<element value="ptad"/>
+			</property>
+		</properties>
+	</rule>
+</ruleset>

--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -3,9 +3,8 @@
 	<description>WordPress Code Sniffs for Post Type Archive Descriptions</description>
 
     <file>./post-type-archive-descriptions.php</file>
-    <file>./compat/qtranslate-x.php</file>
-    <file>./compat/the-events-calendar.php</file>
-    <file>./compat/wordpress-core.php</file>
+    <file>./compat/.</file>
+	<file>./inc/.</file>
 
     <rule ref="WordPress-Extra">
 		<!--

--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -13,6 +13,7 @@
 		Once we know the sniff names, we can opt to exclude sniffs which don't
 		suit our project like so.
         -->
+		<exclude name="WordPress.PHP.YodaConditions.NotYoda"/>
 	</rule>
 
     <config name="minimum_supported_wp_version" value="4.6"/>

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,16 @@
+= 1.5.0 (October 20, 2023) =
+* Tested up to 6.3
+* Adjust the hook which the description is inserted on TEC and make it easier to filter that hook. props @ethanclevenger91
+* Applies all WordPress coding standards sniffs (with one small exception that I'm stuck on). Props @mgratch
+
+= 1.4.0 (June 21, 2022) =
+* Tested up to 6.0.
+* [Fix] The "Edit Archive" admin bar button was broken in the last version. It is now fixed
+* [Fix] Prevent error when editing the Description of a post type that contains "-description" in the post type slug. Hilariously edge-casey.
+* [Fix] Restore archive description before events bar component in The Events Calendar
+* [Dev] Minor code reorganization
+* Want a way to edit the blog page? [Leave your feedback!](https://github.com/mrwweb/post-type-archive-descriptions/issues/22)
+
 = 1.3.1 (June 21, 2022) =
 * Tested up to 6.0.
 * [Fix] The "Edit Archive" admin bar button was broken in the last version. It is now fixed

--- a/compat/qtranslate-x.php
+++ b/compat/qtranslate-x.php
@@ -1,42 +1,39 @@
 <?php
 /**
- * One additional line of compatability is in the `ptad_editor_field` function of the main plugin
+ * Note: One additional line of compatability is in the `ptad_editor_field` function of the main plugin
  */
 if ( ! defined( 'QTX_VERSION' ) ) {
 
 	add_filter( 'ptad_wp_editor_settings', 'ptad_qtranslate_editor_args' );
-
 	/**
 	 * filter editor settings to add necessary text editor classes for support
 	 * @param  array $editor_settings tinymce settings array
 	 * @return array                  filtered settings
 	 */
 	function ptad_qtranslate_editor_args( $editor_settings ) {
-		 $editor_settings['classes'] = $editor_settings['classes'] . ' multilanguage-input qtranxs-translatable';
+		$editor_settings['classes'] = $editor_settings['classes'] . ' multilanguage-input qtranxs-translatable';
 
-		 return $editor_settings;
+		return $editor_settings;
 	}
-	
-	add_filter('qtranslate_load_admin_page_config', 'ptad_qtranslate_support', 99); // 99 priority is important, loaded after registered post types
 
+	// 99 priority is important so it's loaded after registered post types
+	add_filter( 'qtranslate_load_admin_page_config', 'ptad_qtranslate_support', 99 );
 	/**
 	 * filter qtranslate so it knows to pay attention on archive description editor pages
 	 */
 	function ptad_qtranslate_support( $page_configs ) {
 
-		//edit.php?post_type=$post_type&page=
 		$page_config = array();
-		
-		//get post types
+
+		// get post types
 		$post_types = ptad_get_post_types();
 
 		// add a settings section and field for each $post_type
 		foreach ( $post_types as $post_type ) {
 
-			if( post_type_exists( $post_type ) ) {
+			if ( post_type_exists( $post_type ) ) {
 				$page_config['pages'] = array( 'edit.php' => 'post_type=' . $post_type . '&page=' );
 			}
-			
 		}
 
 		$page_config['forms'] = array();
@@ -44,16 +41,15 @@ if ( ! defined( 'QTX_VERSION' ) ) {
 		$f = array();
 
 		$f['fields'] = array();
-		$fields = &$f['fields'];
+		$fields      = &$f['fields'];
 
 		//textarea support
 		$fields[] = array( 'tag' => 'textarea' );
 
 		$page_config['forms'][] = $f;
-		$page_configs[] = $page_config;
+		$page_configs[]         = $page_config;
 
 		return $page_configs;
 
 	}
-
 }

--- a/compat/the-events-calendar.php
+++ b/compat/the-events-calendar.php
@@ -8,16 +8,16 @@ function ptad_tec_description() {
 		'ptad_tribe_template_before_include',
 		'events/v2/components/before'
 	);
-	if( $before_template ) {
-	
+	if ( $before_template ) {
+
 		add_action( 'tribe_template_before_include:' . esc_attr( $before_template ), 'ptad_tribe_events_archive_header' );
 		/**
 		 * Add Title to Events Pages
 		 */
 		function ptad_tribe_events_archive_header() {
-			if(
+			if (
 				is_post_type_archive() &&
-				in_array( 'tribe_events', ptad_get_post_types() )
+				in_array( 'tribe_events', ptad_get_post_types(), true )
 			) {
 				the_archive_description( '<div class="archive-description">', '</div>' );
 			}

--- a/compat/the-events-calendar.php
+++ b/compat/the-events-calendar.php
@@ -6,7 +6,7 @@ add_action( 'init', 'ptad_tec_description' );
 function ptad_tec_description() {
 	$before_template = apply_filters(
 		'ptad_tribe_template_before_include',
-		'events/v2/components/events-bar'
+		'events/v2/components/before'
 	);
 	if( $before_template ) {
 	

--- a/compat/the-events-calendar.php
+++ b/compat/the-events-calendar.php
@@ -1,20 +1,26 @@
 <?php
+add_action( 'init', 'ptad_tec_description' );
 /**
  * Set the template which the Archive Description should appear before in v2 Tribe Events templates - OR - disable automatic output of archive description on Events templates with false
  */
-$before_template = apply_filters( 'ptad_tribe_template_before_include', 'events/v2/components/events-bar' );
-if( $before_template ) {
-
-	add_action( 'tribe_template_before_include:' . esc_attr( $before_template ), 'ptad_tribe_events_archive_header' );
-	/**
-	 * Add Title to Events Pages
-	 */
-	function ptad_tribe_events_archive_header() {
-
-		if( is_post_type_archive() && in_array( 'tribe_events', ptad_get_post_types() ) ) {
-			the_archive_description( '<div class="archive-description">', '</div>' );
+function ptad_tec_description() {
+	$before_template = apply_filters(
+		'ptad_tribe_template_before_include',
+		'events/v2/components/events-bar'
+	);
+	if( $before_template ) {
+	
+		add_action( 'tribe_template_before_include:' . esc_attr( $before_template ), 'ptad_tribe_events_archive_header' );
+		/**
+		 * Add Title to Events Pages
+		 */
+		function ptad_tribe_events_archive_header() {
+			if(
+				is_post_type_archive() &&
+				in_array( 'tribe_events', ptad_get_post_types() )
+			) {
+				the_archive_description( '<div class="archive-description">', '</div>' );
+			}
 		}
-
 	}
-
 }

--- a/compat/wordpress-core.php
+++ b/compat/wordpress-core.php
@@ -1,9 +1,7 @@
 <?php
-/****************************************************
- * 
- * Automatically display content if using *_archive_description() introduced in WordPress 4.1!
- * 
- ****************************************************/
+/**
+ * Automatically display content if using get_archive_description() or the_archive_description() functions introduced in WordPress 4.1!
+ */
 add_filter( 'get_the_archive_description', 'ptad_archive_description' );
 
 /**
@@ -12,7 +10,7 @@ add_filter( 'get_the_archive_description', 'ptad_archive_description' );
  * @return string              post type description if on post type archive
  */
 function ptad_archive_description( $description ) {
-	if( is_post_type_archive( ptad_get_post_types() ) ) {
+	if ( is_post_type_archive( ptad_get_post_types() ) ) {
 		$description = ptad_get_post_type_description();
 	}
 	return $description;

--- a/inc/admin-bar.php
+++ b/inc/admin-bar.php
@@ -1,30 +1,30 @@
 <?php
-/****************************************************
- * 
+/**
  * Add Edit / View Links to the WordPress Admin Bar
- * 
+ *
  * Props: blog.rutwick.com/add-items-anywhere-to-the-wp-3-3-admin-bar
- * 
- ****************************************************/
+ */
 
+add_action( 'admin_bar_menu', 'ptad_admin_bar_links', 100 );
 /**
  * add links to view/edit archive in the admin bar
  */
 function ptad_admin_bar_links( $admin_bar ) {
 
-	if(
+	if (
 		! is_admin()
 		&& is_post_type_archive( ptad_get_post_types() )
 		&& current_user_can( ptad_allow_edit_posts() )
-	 ) {
-		$post_type = ptad_get_post_type_from_queried_object();
+	) {
+		$post_type        = ptad_get_post_type_from_queried_object();
 		$post_type_object = get_post_type_object( $post_type );
 
-		if( is_object( $post_type_object ) ) {
+		if ( is_object( $post_type_object ) ) {
 
 			$post_type_name = $post_type_object->labels->name;
 
-			$link_text = sprintf( __( 'Edit %1$s Description', 'post-type-archive-descriptions' ), $post_type_name );
+			/* translators: %s: post type name */
+			$link_text = sprintf( __( 'Edit %s Description', 'post-type-archive-descriptions' ), $post_type_name );
 
 			/**
 			 * filter the "Edit {Post Type} Description" link
@@ -34,29 +34,31 @@ function ptad_admin_bar_links( $admin_bar ) {
 			$link_text = apply_filters( 'ptad_edit_description_link', $link_text, $post_type_name );
 
 			$parent_page = ptad_settings_page_parent( $post_type, $post_type_object->show_in_menu );
-			
+
 			$args = array(
 				'id'    => 'wp-admin-bar-edit',
 				'title' => $link_text,
-				'href'  => admin_url( $parent_page . '&page=' . $post_type . '-description' )
+				'href'  => admin_url( $parent_page . '&page=' . $post_type . '-description' ),
 			);
 			$admin_bar->add_menu( $args );
 
 		}
 	}
 
-	if( is_admin() && isset( $_GET['page'] ) ) {
+	/* phpcs:ignore WordPress.Security.NonceVerification.Recommended */
+	if ( is_admin() && isset( $_GET['page'] ) ) {
 
-		$screen = get_current_screen();
-		$post_type = ptad_get_post_type_from_admin_page_slug();
-		$slug = $post_type . '-description';
+		$screen              = get_current_screen();
+		$post_type           = ptad_get_post_type_from_admin_page_slug();
+		$slug                = $post_type . '-description';
 		$base_ends_with_slug = substr_compare( $screen->base, $slug, strlen( $screen->base ) - strlen( $slug ), strlen( $slug ) );
 
-		if( 0 === $base_ends_with_slug ) {
+		if ( 0 === $base_ends_with_slug ) {
 
 			$post_type_object = get_post_type_object( $post_type );
-			$post_type_name = $post_type_object->labels->name;
+			$post_type_name   = $post_type_object->labels->name;
 
+			/* translators: %s: post type name */
 			$link_text = sprintf( __( 'View %1$s Archive', 'post-type-archive-descriptions' ), $post_type_name );
 
 			/**
@@ -69,11 +71,10 @@ function ptad_admin_bar_links( $admin_bar ) {
 			$args = array(
 				'id'    => 'wp-admin-bar-edit',
 				'title' => $link_text,
-				'href'  => get_post_type_archive_link( $post_type )
+				'href'  => get_post_type_archive_link( $post_type ),
 			);
 			$admin_bar->add_menu( $args );
 		}
 	}
 
 }
-add_action('admin_bar_menu', 'ptad_admin_bar_links',  100);

--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -1,18 +1,16 @@
 <?php
-/****************************************************
- *
- * Get post types for plugin, filterable by users
- *
- ****************************************************/
 /**
- * return array of post types that should use the Post Type Archive Description
+ * Get post types that should use the Post Type Archive Description
+ *
+ * Adjust this this list with `ptad_post_types` filter
+ *
  * @return array post types to use description with (default, all non-built-in with archive)
  */
 function ptad_get_post_types() {
 
-	$args = array(
-		'_builtin' => false,
-		'has_archive' => true
+	$args       = array(
+		'_builtin'    => false,
+		'has_archive' => true,
 	);
 	$post_types = apply_filters( 'ptad_post_types', get_post_types( $args ) );
 
@@ -20,13 +18,20 @@ function ptad_get_post_types() {
 
 }
 
+/**
+ * Extract a post type slug from the admin page slug
+ */
 function ptad_get_post_type_from_admin_page_slug() {
-	$page = $_GET['page'];
+	/* phpcs:ignore WordPress.Security.NonceVerification.Recommended */
+	$page      = $_GET['page'];
 	$post_type = preg_replace( '/-description$/', '', $page );
 
 	return $post_type;
 }
 
+/**
+ * Get the post type from the queried object
+ */
 function ptad_get_post_type_from_queried_object() {
 	$queried_object = get_queried_object();
 	return $queried_object->name;

--- a/inc/settings.php
+++ b/inc/settings.php
@@ -1,27 +1,24 @@
 <?php
-/****************************************************
- * 
+/**
  * Register Menu Pages, Settings, and Callbacks
- * 
- ****************************************************/
+ */
 
 add_action( 'admin_menu', 'ptad_enable_pages' );
 /**
  * Register admin pages for description field
  */
-
 function ptad_enable_pages() {
 
 	$post_types = ptad_get_post_types();
 
 	foreach ( $post_types as $post_type ) :
 
-		if( post_type_exists( $post_type ) ) :
+		if ( post_type_exists( $post_type ) ) :
 
 			// Check if post type has a particular parent menu location
 			$post_type_object = get_post_type_object( $post_type );
 			$show_in_menu     = $post_type_object->show_in_menu;
-		    
+
 			add_submenu_page(
 				ptad_settings_page_parent( $post_type, $show_in_menu ), // $parent slug
 				ptad_settings_page_title( $post_type, 'name' ), // $page_title
@@ -37,11 +34,10 @@ function ptad_enable_pages() {
 
 }
 
+add_action( 'admin_init', 'ptad_register_settings' );
 /**
  * Register Setting, Settings Section, and Settings Field
  */
-
-add_action( 'admin_init', 'ptad_register_settings' );
 function ptad_register_settings() {
 
 	$post_types = ptad_get_post_types();
@@ -56,7 +52,7 @@ function ptad_register_settings() {
 	// add a settings section and field for each $post_type
 	foreach ( $post_types as $post_type ) :
 
-		if( post_type_exists( $post_type ) ) :
+		if ( post_type_exists( $post_type ) ) :
 
 			// Register settings and call sanitization functions
 			add_settings_section(
@@ -74,9 +70,9 @@ function ptad_register_settings() {
 				$post_type . '-description', // $page
 				'ptad_settings_section_' . $post_type, // $section
 				array( // $args
-					'post_type' => $post_type,
+					'post_type'  => $post_type,
 					'field_name' => 'ptad_descriptions[' . $post_type . ']',
-					'label_for' => 'ptad_descriptions[' . $post_type . ']'
+					'label_for'  => 'ptad_descriptions[' . $post_type . ']',
 				)
 			);
 
@@ -90,14 +86,14 @@ function ptad_register_settings() {
 function ptad_settings_section_callback( $args ) {
 
 	$post_type = str_replace( 'ptad_settings_section_', '', $args['id'] );
-	
+
 	/**
 	 * Action before Description editor field in the admin
 	 *
-	 * $post_type 	slug of post type the description is for
+	 * $post_type   slug of post type the description is for
 	 */
 	do_action( 'ptad_before_editor', $post_type );
-	
+
 	/**
 	 * Action before Description editor field in the admin only for a specific post type
 	 *
@@ -116,8 +112,8 @@ function ptad_editor_field( $args ) {
 
 	$descriptions = (array) get_option( 'ptad_descriptions' );
 
-	if( array_key_exists($post_type, $descriptions) ) {
-		$description = $descriptions[$post_type];
+	if ( array_key_exists( $post_type, $descriptions ) ) {
+		$description = $descriptions[ $post_type ];
 	} else {
 		$description = '';
 	}
@@ -126,7 +122,7 @@ function ptad_editor_field( $args ) {
 		'textarea_name' => $args['field_name'],
 		'textarea_rows' => 15,
 		'media_buttons' => true,
-		'classes' 		=> 'wp-editor-area wp-editor'
+		'classes'       => 'wp-editor-area wp-editor',
 	);
 
 	$editor_settings = apply_filters( 'ptad_wp_editor_settings', $editor_settings, $args, $description );
@@ -136,21 +132,21 @@ function ptad_editor_field( $args ) {
 	/**
 	 * Action before Description editor field in the admin
 	 *
-	 * $post_type 	slug of post type the description is for
+	 * $post_type   slug of post type the description is for
 	 */
 	do_action( 'ptad_after_editor', $post_type );
-	
+
 	/**
 	 * Action before Description editor field in the admin only for a specific post type
 	 *
 	 * example add_action( 'ptad_after_editor_my_custom_post_type', 'mycpt_action' );
 	 */
 	do_action( 'ptad_after_editor_' . $post_type );
-	
+
 	if ( ! defined( 'QTX_VERSION' ) ) {
 		add_filter( 'the_editor', 'qtranslate_admin_loadConfig' );
 	}
-	
+
 }
 
 /**
@@ -159,13 +155,12 @@ function ptad_editor_field( $args ) {
 function ptad_settings_page( $post_type ) {
 
 	// occurs when parent menu item is not the post type
-	if( empty( $post_type ) ) {
+	if ( empty( $post_type ) ) {
 		$post_type = ptad_get_post_type_from_admin_page_slug();
 	}
 	?>
-
 	<div class="wrap">
-		<h2><?php echo ptad_settings_page_title( $post_type, 'name' ); ?></h2>
+		<h2><?php echo wp_kses_post( ptad_settings_page_title( $post_type, 'name' ) ); ?></h2>
 		<form action="options.php" method="POST">
 			<?php settings_fields( 'ptad_descriptions' ); ?>
 			<?php do_settings_sections( $post_type . '-description' ); ?>
@@ -185,8 +180,8 @@ function ptad_sanitize_inputs( $input ) {
 	$all_descriptions = (array) get_option( 'ptad_descriptions' );
 
 	// sanitize input
-	foreach( $input as $post_type => $description ) {
-		$sanitized_input[$post_type] = wp_kses_post( $description );
+	foreach ( $input as $post_type => $description ) {
+		$sanitized_input[ $post_type ] = wp_kses_post( $description );
 	}
 
 	// merge with other descriptions into array setting
@@ -198,7 +193,7 @@ function ptad_sanitize_inputs( $input ) {
 
 /**
  * Return capability that's allowed to edit posts
- * 
+ *
  * See: http://core.trac.wordpress.org/ticket/14365
  */
 function ptad_allow_edit_posts() {
@@ -207,11 +202,11 @@ function ptad_allow_edit_posts() {
 
 	/**
 	 * filter the capability for who can edit descriptions
-	 * 
+	 *
 	 * @param string $capability capability required to edit post type descriptions (default: edit_posts)
 	 */
 	$capability = apply_filters( 'ptad_description_capability', $capability );
-	
+
 	return esc_attr( $capability );
 
 }
@@ -225,14 +220,14 @@ add_filter( 'option_page_capability_ptad_descriptions', 'ptad_allow_edit_posts' 
  * @return bool|string parent for settings page
  */
 function ptad_settings_page_parent( $post_type, $show_in_menu = false ) {
- 
+
 	$settings_page_parent = $show_in_menu;
-	
+
 	// Default is standard post type editing screen
-	if( $settings_page_parent && is_bool( $settings_page_parent ) ) {
+	if ( $settings_page_parent && is_bool( $settings_page_parent ) ) {
 		$settings_page_parent = "edit.php?post_type=$post_type";
 	}
-	
+
 	/**
 	 * filter for parent of Archive Settings page
 	 *
@@ -247,22 +242,23 @@ function ptad_settings_page_parent( $post_type, $show_in_menu = false ) {
 
 /**
  * Output filterable name of Settings page
- * 
+ *
  * @param string $post_type name of post type for the page
- * @param 'label'|'name' $pt_val whether $post_type is the label (default) or name
+ * @param 'label'|'name' $post_type_value whether $post_type is the label (default) or name
  * @return name for settings page
  */
-function ptad_settings_page_title( $post_type, $pt_val = 'label' ) {
+function ptad_settings_page_title( $post_type, $post_type_value = 'label' ) {
 
-	if( $pt_val == 'name' ) {
+	if ( $post_type_value === 'name' ) {
 		$post_type_info = get_post_types( array( 'name' => $post_type ), 'objects' );
-		$post_type = $post_type_info[$post_type]->labels->name;
+		$post_type      = $post_type_info[ $post_type ]->labels->name;
 	}
-	$settings_page_title = sprintf( __( 'Description for the %1$s Archive', 'post-type-archive-descriptions' ), $post_type );
+	/* translators: %s: post type name */
+	$settings_page_title = sprintf( __( 'Description for the %s Archive', 'post-type-archive-descriptions' ), $post_type );
 
 	/**
 	 * filter for admin menu label
-	 * 
+	 *
 	 * @param string $settings_page_menu_label label text (default: "Description for the {Post Type} Archive")
 	 * @param string $post_type post_type name if needed
 	 */
@@ -275,21 +271,21 @@ function ptad_settings_page_title( $post_type, $pt_val = 'label' ) {
 /**
  * Output filterable menu label for a post type's description settings page.
  * @param  string $post_type post_type to create label for
- * @param 'label'|'name' $pt_val whether $post_type is the label (default) or name
+ * @param 'label'|'name' $post_type_value whether $post_type is the label (default) or name
  * @return string            admin menu label
  */
-function ptad_settings_menu_label( $post_type, $pt_val = 'label' ) {
+function ptad_settings_menu_label( $post_type, $post_type_value = 'label' ) {
 
-	if( $pt_val == 'name' ) {
+	if ( $post_type_value === 'name' ) {
 		$post_type_info = get_post_types( array( 'name' => $post_type ), 'objects' );
-		$post_type = $post_type_info[$post_type]->labels->name;
+		$post_type      = $post_type_info[ $post_type ]->labels->name;
 	}
 
 	$settings_page_menu_label = __( 'Archive Description', 'post-type-archive-descriptions' );
 
 	/**
 	 * filter for admin menu label
-	 * 
+	 *
 	 * @param string $settings_page_menu_label label text (default: "Description")
 	 * @param string $post_type post_type name if needed
 	 */

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -1,14 +1,14 @@
 <?php
-/****************************************************
- * 
- * Functions to get Description Page Content
- * 
- ****************************************************/
 /**
- * echo post type archive description
- * 
- * if on a post type archive, automatically grabs current post type
- * 
+ * Private/Legacy functions to get the description page content
+ *
+ * Developers: To display the archive description use get_the_archive_description() or the_archive_description().
+ */
+/**
+ * Echo the post type archive description
+ *
+ * If on a post type archive, automatically grabs current post type
+ *
  * @param  string $post_type slug for post type to show description for (optional)
  * @return string            post type description
  */
@@ -17,28 +17,30 @@ function ptad_the_post_type_description( $post_type = '' ) {
 }
 
 /**
- * return post type archive description
- * 
- * if on a post type archive, automatically grabs current post type
- * 
+ * Return post type archive description
+ *
+ * If on a post type archive, automatically grabs current post type
+ *
  * @param  string $post_type slug for post type to show description for (optional)
  * @return string            post type description
  */
 function ptad_get_post_type_description( $post_type = '' ) {
-	
+
 	// get global $post_type if not specified
-	if ( '' == $post_type ) {
+	if ( '' === $post_type ) {
 		$post_type = ptad_get_post_type_from_queried_object();
 	}
 
 	$all_descriptions = (array) get_option( 'ptad_descriptions' );
 
-	if( array_key_exists($post_type, $all_descriptions) ) {
-		$post_type_description = $all_descriptions[$post_type];
+	if ( array_key_exists( $post_type, $all_descriptions ) ) {
+		$post_type_description = $all_descriptions[ $post_type ];
 	} else {
 		$post_type_description = '';
 	}
 
+	// Intentionally run the description through the_content filter
+	// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
 	$description = apply_filters( 'the_content', $post_type_description );
 
 	return $description;

--- a/post-type-archive-descriptions.php
+++ b/post-type-archive-descriptions.php
@@ -25,11 +25,11 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-require_once( 'inc/helpers.php' );
-require_once( 'inc/settings.php' );
-require_once( 'inc/admin-bar.php' );
-require_once( 'inc/template-tags.php' );
+require_once 'inc/helpers.php';
+require_once 'inc/settings.php';
+require_once 'inc/admin-bar.php';
+require_once 'inc/template-tags.php';
 
-require_once( 'compat/wordpress-core.php' );
-require_once( 'compat/qtranslate-x.php' );
-require_once( 'compat/the-events-calendar.php' );
+require_once 'compat/wordpress-core.php';
+require_once 'compat/qtranslate-x.php';
+require_once 'compat/the-events-calendar.php';

--- a/post-type-archive-descriptions.php
+++ b/post-type-archive-descriptions.php
@@ -4,7 +4,7 @@ Plugin Name: Post Type Archive Descriptions
 Description: Enables an editable description for a post type to display at the top of the post type archive page.
 Author: Mark Root-Wiley, MRW Web Design, NonprofitWP.org
 Author URI: https://MRWweb.com
-Version: 1.4.0
+Version: 1.5.0
 License: GPL v3
 Text Domain: post-type-archive-descriptions
 

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 Tags: custom post type, custom post types, post type archive, archives, custom post type archive
 Requires at least: 4.6
-Tested up to: 6.0
+Tested up to: 6.3
 Stable tag: 1.4.0
 
 == Description ==
@@ -109,6 +109,11 @@ Actions:
 2. The post type archive description displayed (automatically!) in the Twenty Fifteen theme. The plugin also adds the "Edit Books Description" link in the Admin Bar.
 
 == Changelog ==
+= 1.5.0 (October 20, 2023) =
+* Tested up to 6.3
+* Adjust the hook which the description is inserted on TEC and make it easier to filter that hook. props @ethanclevenger91
+* Applies all WordPress coding standards sniffs (with one small exception that I'm stuck on). Props @mgratch
+
 = 1.4.0 (June 21, 2022) =
 * Tested up to 6.0.
 * [Fix] The "Edit Archive" admin bar button was broken in the last version. It is now fixed
@@ -119,4 +124,4 @@ Actions:
 
 == Upgrade Notice ==
 = 1.4.0 =
-Tested up to WP 6.0. Restore missing "Edit Description" buttons in admin bar and description on The Events Calendar calendar page.
+Tested up to WP 6.3. Change where description appears on The Events Calendar pages. Code formatting and quality improvements.


### PR DESCRIPTION
- Closes #23 and Closes #25 - Adjust the hook which the description is inserted on TEC and make it easier to filter that hook. props @ethanclevenger91
- Closes #27 - Applies all WordPress coding standards sniffs (with one small exception that I'm stuck on). Props @mgratch